### PR TITLE
Ask board about firmware version manually

### DIFF
--- a/src/clodiuno/firmata.clj
+++ b/src/clodiuno/firmata.clj
@@ -142,6 +142,8 @@
                (.addEventListener (listener #(process-input conn (.getInputStream (:port @conn)))))
                (.notifyOnDataAvailable true))
 
+             (write-bytes conn REPORT-VERSION)
+
 	     (while (nil? (:version @conn))
                (Thread/sleep 100))
 


### PR DESCRIPTION
Useful for bluetooth connections or boards based on ATmega32u4.

Tested on UNO + Bluetooth and Arduino Leonardo.

Also works fine on wired UNO.
