### PR TITLE
Added Firmata I2C Support and Sampling interval

### DIFF
--- a/src/clodiuno/core.clj
+++ b/src/clodiuno/core.clj
@@ -40,6 +40,40 @@
   "Write an analog value (PWM-wave) to a digital pin."
   (fn [type _ _] (type :interface)))
 
+(defmulti set-sampling-interval
+  "Set the Sampling Interval, that is, how often analog data and I2C data is reported to the client"
+  (fn [type _] (type :interface)))
+
+(defmulti i2c-init
+  "You need to call this before doing ANY I2C work.
+   delay: microseconds to wait between receiving a firmata read
+   request and sending it to the slave. Needed by some devices like
+   WiiNunchuck. Default is 19ms"
+  (fn [type & _] (type :interface)))
+
+(defmulti i2c-blocking-read
+  "Make a single read request to a I2C device in a blocking way"
+  (fn [type & _] (type :interface)))
+
+(defmulti i2c-write
+  "Write to I2C device"
+  (fn [type & _] (type :interface)))
+
+(defmulti i2c-start-reading
+  "Read continously from I2C device. This will register an slave-addr+register
+   entry in the Board. The board then issues I2C read requests at sampling-interval
+   freq, and reports back to the host. You can access these lectures using i2c-read.
+   Will read indefinitely until i2c-stop-reading is called for that particular device. "
+  (fn [type & _] (type :interface)))
+
+(defmulti i2c-stop-reading
+  "Stop reading continuously from I2C device"
+  (fn [type & _] (type :interface)))
+
+(defmulti i2c-read
+  "Read from I2C device. Before using this function you need to start reading using i2c-start-reading"
+  (fn [type _ _] (type :interface)))
+
 (defmulti close
   "Close serial interface."
   (fn [type] (type :interface)))

--- a/src/clodiuno/firmata.clj
+++ b/src/clodiuno/firmata.clj
@@ -18,6 +18,40 @@
 (def START-SYSEX      0xF0) ;;start a MIDI SysEx message
 (def END-SYSEX        0xF7) ;;end a MIDI SysEx message
 
+;; SYSEX extended commands
+(def RESERVED-COMMAND        0x00) ;;2nd SysEx data byte is a chip-specific command (AVR, PIC, TI, etc).
+(def ANALOG-MAPPING-QUERY    0x69) ;;ask for mapping of analog to pin numbers
+(def ANALOG-MAPPING-RESPONSE 0x6A) ;;reply with mapping info
+(def CAPABILITY-QUERY        0x6B) ;;ask for supported modes and resolution of all pins
+(def CAPABILITY-RESPONSE     0x6C) ;;reply with supported modes and resolution
+(def PIN-STATE-QUERY         0x6D) ;;ask for a pin's current mode and value
+(def PIN-STATE-RESPONSE      0x6E) ;;reply with a pin's current mode and value
+(def EXTENDED-ANALOG         0x6F) ;;analog write (PWM, Servo, etc) to any pin
+(def SERVO-CONFIG            0x70) ;;set max angle, minPulse, maxPulse, freq
+(def STRING-DATA             0x71) ;;a string message with 14-bits per char
+(def SHIFT-DATA              0x75) ;;shiftOut config/data message (34 bits)
+(def I2C-REQUEST             0x76) ;;I2C request messages from a host to an I/O board
+(def I2C-REPLY               0x77) ;;I2C reply messages from an I/O board to a host, only for read/read-continously
+(def I2C-CONFIG              0x78) ;;Configure special I2C settings such as power pins and delay times
+(def REPORT-FIRMWARE         0x79) ;;report name and version of the firmware
+(def SAMPLING-INTERVAL       0x7A) ;;sampling interval
+(def SYSEX-NON-REALTIME      0x7E) ;;MIDI Reserved for non-realtime messages
+(def SYSEX-REALTIME          0x7F) ;;MIDI Reserved for realtime messages
+
+;; Taken from StandardFirmata.ino
+(def I2C-WRITE                   2r00000000)
+(def I2C-READ                    2r00001000)
+;; read-continously indicates that the firmware should continuously
+;; read the device at the rate specified by the sampling interval.
+;; firmware implementation should support read continuous mode for
+;; several I2C devices simultaneously. Sending the stop reading
+;; command will end read continuous mode for that particular device.
+(def I2C-READ-CONTINUOUSLY       2r00010000)
+(def I2C-STOP-READING            2r00011000)
+(def I2C-READ-WRITE-MODE-MASK    2r00011000)
+(def I2C-10BIT-ADDRESS-MODE-MASK 2r00100000)
+
+
 (def arduino-port-count 7)
 
 (defn- byte [v]
@@ -65,6 +99,22 @@
       (.write out b))
     (.flush out)))
 
+(defn- lsb [b]
+  (bit-and b 0x7F))
+
+(defn- msb [b]
+  (bit-and (bit-shift-right b 7) 0x7F))
+
+(defn- bytes-to-int [lsb msb]
+  (bit-or (bit-shift-left (bit-and msb 0x7F) 7) 
+          (bit-and lsb 0x7F)))
+
+(defn- write-data [conn data]
+  (when (not (empty? data))
+    (apply write-bytes conn 
+           (mapcat (fn [b] [(lsb b) (msb b)])
+                   data))))
+
 (defn- bits [n]
   (map #(bit-and (bit-shift-right n %) 1) (range 8)))
 
@@ -73,6 +123,21 @@
 
 (defn- assoc-in! [r ks v]
   (dosync (alter r assoc-in ks v)))
+
+(defn- i2c-request [conn slave-addr mode data]
+   {:pre  [(<= slave-addr 127)]} ;; Current arduino firmata doesn't support 10-bit addressing. 
+   (doto conn
+       (write-bytes START-SYSEX 
+                    I2C-REQUEST 
+                    (lsb slave-addr)
+                    (bit-or (bit-and (msb slave-addr) 
+                                     (bit-not I2C-READ-WRITE-MODE-MASK)) 
+                            mode)
+                    )
+       (write-data  data)
+       (write-bytes END-SYSEX)
+       )
+   )
 
 ;;
 ;; Firmata Calls
@@ -111,11 +176,87 @@
 (defmethod analog-write :firmata [conn pin val]
   (write-bytes conn (bit-or ANALOG-MESSAGE (bit-and pin 0x0F)) (bit-and val 0x7F) (bit-shift-right val 7)))
 
+;; default 19 (ms)
+(defmethod set-sampling-interval :firmata [conn delay]
+  (write-bytes conn START-SYSEX SAMPLING-INTERVAL (lsb delay) (msb delay) END-SYSEX)
+)
+
+;; default delay = 19 (ms)
+(defmethod i2c-init :firmata [conn & {:keys [delay] :or {delay 19}}]
+  (write-bytes conn START-SYSEX I2C-CONFIG (lsb delay) (msb delay) END-SYSEX))
+
+(defmethod i2c-blocking-read :firmata [conn slave-addr register bytes-to-read  & {:keys [timeout]}]
+  ;; Note, Firmata protocol doesn't allows you to distingish between
+  ;; read replies and read-continously reports, both are marked as I2C_REPLY
+  ;; If a report comes for that slave-addr/register it will be taken
+  ;; as the response of the i2c-blocking-read command.
+  ;;
+  ;; Register can be nil
+  (let [reply (promise)]
+    (assoc-in! conn [:i2c :last-blocking-read] {:slave-addr slave-addr
+                                               :register   (or register -1)
+                                               :response   reply})
+    
+    (i2c-request conn slave-addr I2C-READ (if register [register bytes-to-read] [bytes-to-read]))
+    (if timeout
+      (deref reply timeout nil)
+      @reply)))
+  
+(defmethod i2c-write :firmata 
+  ([conn slave-addr data]          (i2c-request conn slave-addr I2C-WRITE data))
+  ([conn slave-addr register data] (i2c-request conn slave-addr I2C-WRITE (concat [register] data))))
+
+(defmethod i2c-start-reading :firmata [conn slave-addr register bytes-to-read]
+  (i2c-request conn slave-addr I2C-READ-CONTINUOUSLY [register bytes-to-read]))
+
+(defmethod i2c-stop-reading :firmata [conn slave-addr]
+  (i2c-request conn slave-addr I2C-STOP-READING []))
+
+(defmethod i2c-read :firmata [conn slave-addr register]
+  (get-in @conn [:i2c slave-addr register]))
+
+
 (defn- read-multibyte [in]
   (let [lsb (.read in)
         msb (.read in)
         val (bit-or (bit-shift-left msb 7) lsb)]
     [lsb msb val]))
+
+(defn- read-to-sysex-end [in]
+  (loop [buffer    []]
+    (let [b (.read in)]
+      (if (= b END-SYSEX) 
+        buffer
+        (recur (conj buffer b))))))
+
+(defn- multibytes-to-ints [list]
+  (for [[lsb msb] (partition 2 list)] (bytes-to-int lsb msb)))
+
+(defn- handle-sysex [conn in]
+  (let [cmd (.read in)]
+    (cond
+     (= cmd REPORT-FIRMWARE) (let [major-version (.read in)
+                                   minor-version (.read in)
+                                   firmware-name (apply str (map char (read-to-sysex-end in)))]
+                               (assoc-in! conn [:firmware] {:version [major-version minor-version] 
+                                                            :name firmware-name}))
+     (= cmd STRING-DATA) (let [packet    (read-to-sysex-end in)
+                               msg       (apply str (map char packet))]
+                           (println "Message from Board:" msg))
+
+     (= cmd I2C-REPLY) (let [packet    (read-to-sysex-end in)
+                             [slave-addr
+                              register
+                              & data] (multibytes-to-ints packet)
+                             r        (get-in @conn [:i2c :last-blocking-read])]
+                         (if (and r (= (:slave-addr r) slave-addr)
+                                    (= (:register   r) register)
+                                    (not (realized? (:response r))))
+                           (deliver (:response r) data)
+                           (assoc-in! conn [:i2c slave-addr register] data))
+                         )
+     :unknown-cmd  (read-to-sysex-end in) ;; discard
+     )))
 
 (defn- process-input
   "Parse input from firmata."
@@ -131,7 +272,10 @@
                                                      [lsb msb val] (read-multibyte in)]
                                                  (assoc-in! conn [:digital-in port] (bits val)))
 
-       (= data REPORT-VERSION) (assoc-in! conn [:version] [(.read in) (.read in)])))))
+       (= data REPORT-VERSION) (assoc-in! conn [:version] [(.read in) (.read in)])
+
+       (= data START-SYSEX) (handle-sysex conn in)))))
+
 
 (defmethod arduino :firmata [type port & {:keys [baudrate] :or {baudrate 57600}}]
   (let [port (open (port-identifier port) baudrate)
@@ -151,5 +295,7 @@
 
     (dotimes [i arduino-port-count]
       (assoc-in! conn [:digital-in i] (repeat 8 0)))
+
+    (assoc-in! conn [:i2c] {:last-blocking-read nil})
 
     conn))


### PR DESCRIPTION
Added Firmata support for:
- I2C bus commands
- setting the sampling interval for I2C and Digital/Analog IO lectures
- parsing String messages coming from the board (now printed to the console)
- parsing the firmware string
